### PR TITLE
Added definable serial support for LinkIt Smart w/Arduino modules

### DIFF
--- a/Nanpy/BaseClass.h
+++ b/Nanpy/BaseClass.h
@@ -26,7 +26,7 @@ namespace nanpy {
                 if (strcmp(m->getName(), "remove") == 0) {
                     delete(v[m->getObjectId()]);
                     v.remove(m->getObjectId());
-                    Serial.println("0");
+                    COMM_SERIAL.println("0");
                 }
             }
 

--- a/Nanpy/ComChannel.cpp
+++ b/Nanpy/ComChannel.cpp
@@ -142,7 +142,7 @@ void readLineFromSerial(char* extbuff) {
     char ch = '0';
     char* buff = nanpy::ComChannel::read_buffer;
     do {
-        ch = Serial.read();
+        ch = COMM_SERIAL.read();
         if(ch < 255 && ch >= 0) {
             buff[i++] = ch;
         }
@@ -155,46 +155,46 @@ void readLineFromSerial(char* extbuff) {
 };
 
 bool nanpy::ComChannel::available() {
-    if (Serial.available() > 0)
+    if (COMM_SERIAL.available() > 0)
         return true;
     else
         return false;
 }
 
 void nanpy::ComChannel::connect() {
-    Serial.begin(BAUDRATE);
+    COMM_SERIAL.begin(BAUDRATE);
 }
 
 void nanpy::ComChannel::println(String& val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(const char* val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(int val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(unsigned int val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(float val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(double val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(long val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::println(unsigned long val) {
-    Serial.println(val);
+    COMM_SERIAL.println(val);
 }
 
 void nanpy::ComChannel::readLine(char* extbuff) {

--- a/Nanpy/MethodDescriptor.cpp
+++ b/Nanpy/MethodDescriptor.cpp
@@ -94,6 +94,14 @@ void nanpy::MethodDescriptor::returns(const char* val) {
     ComChannel::println(val);
 }
 
+void nanpy::MethodDescriptor::returns(char val) {
+    ComChannel::println(val);
+}
+
+void nanpy::MethodDescriptor::returns(unsigned char val) {
+    ComChannel::println(val);
+}
+
 void nanpy::MethodDescriptor::returns(int val) {
     ComChannel::println(val);
 }

--- a/Nanpy/MethodDescriptor.h
+++ b/Nanpy/MethodDescriptor.h
@@ -30,6 +30,8 @@ namespace nanpy {
             char* getName();
             void returns(String& val);
             void returns(const char* val);
+            void returns(char val);
+            void returns(unsigned char val);
             void returns(int val);
             void returns(unsigned int val);
             void returns(float val);

--- a/Nanpy/cfg_defaults.h
+++ b/Nanpy/cfg_defaults.h
@@ -4,6 +4,10 @@
 
 // All these settings can be overwritten in cfg.h
 
+#ifndef COMM_SERIAL
+#  define COMM_SERIAL 				Serial
+#endif
+
 #ifndef USE_WIFI_CONNECTION
 #  define USE_WIFI_CONNECTION   0
 #endif


### PR DESCRIPTION
Instead of using 'Serial' directly, COMM_SERIAL is defined. By default it is Serial, but can be changed in cfg.h. For the LinkIt Smart, it should be defined to Serial1. The LinkIt Smart is a Linux-based module sold by SeeedStudio.

Also added are two new return types to complete MethodDescriptor support.